### PR TITLE
Updated to work with a specific "scrolling element" selector setting

### DIFF
--- a/src/_directive.js
+++ b/src/_directive.js
@@ -86,9 +86,13 @@ function onBind(el, { modifiers = {}, value = {} }) {
 
 function init(el, settings) {
   // START PARALLAX FROM MIDDLE OR BOTTOM OF THE SCREEN
+  const innerHeight =
+  settings.scrollingElement.innerHeight ||
+  settings.scrollingElement.clientHeight
+
   const startingPoint = settings.startParallaxFromBottom
-    ? settings.scrollingElement.clientHeight
-    : settings.scrollingElement.clientHeight / 2
+    ? innerHeight
+    : innerHeight / 2
 
   const pageYOffset =
     settings.scrollingElement.scrollTop ||


### PR DESCRIPTION
Fix for https://github.com/gerasimvol/vue-prlx/issues/40

I also ran it through Prettier, but did it did some small formatting changes that you may not want but I was too far gone to change it back. If you provide a Prettier config you like I can use that.

The new settings work like this:
```
        v-prlx="{
            scrollingElement: '#my-scrolling-div'
        }"
```

Or if you don't set `scrollingElement` it will just use `window` as it always did.

You'd also want to update the docs, but I don't see them included in this repo.

